### PR TITLE
Update ConfigurationsSeeder.php

### DIFF
--- a/src/Seeder/Configurations/ConfigurationsSeeder.php
+++ b/src/Seeder/Configurations/ConfigurationsSeeder.php
@@ -79,7 +79,7 @@ class ConfigurationsSeeder extends Seeder
                     'id' => 6,
                     'key' => 'adminPanelVerifyEmail',
                     'display_name' => 'Should verify email after register',
-                    'value' => '1',
+                    'value' => '0',
                     'details' => '',
                     'type' => 'switch',
                     'order' => 6,


### PR DESCRIPTION
It's avoid error for register when new installed because forget to add the smtp or email gateway, it should be a extra option and not default