### PR TITLE
fix avatar handle delete file

### DIFF
--- a/src/Controllers/BadasoUserController.php
+++ b/src/Controllers/BadasoUserController.php
@@ -148,7 +148,9 @@ class BadasoUserController extends Controller
             ]);
 
             $user = User::find($request->id);
-            $this->handleDeleteFile($user->avatar);
+            if (!is_null($user->avatar))  {
+                $this->handleDeleteFile($user->avatar);
+            }
             $user->delete();
 
             DB::commit();
@@ -183,7 +185,9 @@ class BadasoUserController extends Controller
             foreach ($id_list as $key => $id) {
                 $user = User::find($id);
                 $user_name[] = $user->name;
-                $this->handleDeleteFile($user->avatar);
+                if (!is_null($user->avatar))  {
+                    $this->handleDeleteFile($user->avatar);
+                }
                 $user->delete();
             }
             $user_name = join(',', $user_name);


### PR DESCRIPTION
Hi, request for a review. I tried the fix from issue #875.

I have added a filter when the admin deletes a user whose avatar is still empty, then the file delete handle function will not be executed